### PR TITLE
Fix Twitter link in example site footer

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -19,12 +19,13 @@ url = "https://github.com/athul/archie"
 [[params.social]]
 name = "Twitter"
 icon = "twitter"
-url = "https://github.com/athulcajay/"
+url = "https://twitter.com/athulcajay/"
 
 [[params.social]]
 name = "GitLab"
 icon = "gitlab"
 url = "https://gitlab.com/athul/"
+
 [[menu.main]]
 name = "Home"
 url = "/"


### PR DESCRIPTION
Looks like there's a copy-and-paste error in the example site's `config.toml`, as the Twitter link currently points to GitHub with an invalid username.